### PR TITLE
Allow external diff util via --diff

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
   ] ++ (lib.optional stdenv.cc.isClang [ pkgs.bear pkgs.clang-tools ]);
 
   postInstall = ''
-    wrapProgram "$out/bin/nix-unit" --prefix PATH : ${lib.getExe difftastic}
+    wrapProgram "$out/bin/nix-unit" --prefix PATH : ${difftastic}/bin
   '';
 
   meta = {

--- a/default.nix
+++ b/default.nix
@@ -3,6 +3,8 @@
 , nix
 , pkgs
 , srcDir ? null
+, makeWrapper
+, difftastic
 }:
 
 let
@@ -19,6 +21,7 @@ stdenv.mkDerivation {
     boost
   ];
   nativeBuildInputs = with pkgs; [
+    makeWrapper
     bear
     meson
     pkg-config
@@ -27,11 +30,16 @@ stdenv.mkDerivation {
     cmake
   ] ++ (lib.optional stdenv.cc.isClang [ pkgs.bear pkgs.clang-tools ]);
 
+  postInstall = ''
+    wrapProgram "$out/bin/nix-unit" --prefix PATH : ${lib.getExe difftastic}
+  '';
+
   meta = {
     description = "Nix unit test runner";
     homepage = "https://github.com/adisbladis/nix-unit";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ adisbladis ];
     platforms = lib.platforms.unix;
+    mainProgram = "nix-unit";
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,10 @@
                 pythonEnv = pkgs.python3.withPackages (_ps: [ ]);
               in
               pkgs.mkShell {
-                nativeBuildInputs = self'.packages.nix-unit.nativeBuildInputs ++ [ pythonEnv ];
+                nativeBuildInputs = self'.packages.nix-unit.nativeBuildInputs ++ [
+                  pythonEnv
+                  pkgs.difftastic
+                ];
                 inherit (self'.packages.nix-unit) buildInputs;
                 shellHook = lib.optionalString stdenv.isLinux ''
                   export NIX_DEBUG_INFO_DIRS="${pkgs.curl.debug}/lib/debug:${drvArgs.nix.debug}/lib/debug''${NIX_DEBUG_INFO_DIRS:+:$NIX_DEBUG_INFO_DIRS}"

--- a/src/nix-unit.cc
+++ b/src/nix-unit.cc
@@ -198,7 +198,7 @@ void runDiffTool(std::string diffTool, std::string_view actual,
     auto res = runProgram(RunOptions{
         .program = "/bin/sh",
         .searchPath = true,
-        .args = {"-c", diffTool + " " + actualPath + " " + expectedPath},
+        .args = {"-c", diffTool + " --color always " + actualPath + " " + expectedPath},
     });
     if (!(WIFEXITED(res.first) &&
           (WEXITSTATUS(res.first) == 0 || WEXITSTATUS(res.first) == 1))) {

--- a/src/nix-unit.cc
+++ b/src/nix-unit.cc
@@ -198,7 +198,8 @@ void runDiffTool(std::string diffTool, std::string_view actual,
     auto res = runProgram(RunOptions{
         .program = "/bin/sh",
         .searchPath = true,
-        .args = {"-c", diffTool + " --color always " + actualPath + " " + expectedPath},
+        .args = {"-c", diffTool + " --color always " + actualPath + " " +
+                           expectedPath},
     });
     if (!(WIFEXITED(res.first) &&
           (WEXITSTATUS(res.first) == 0 || WEXITSTATUS(res.first) == 1))) {
@@ -280,8 +281,8 @@ static TestResults runTests(ref<EvalState> state, Bindings &autoArgs) {
                 if (success) {
                     results.success++;
                 } else {
-                  runDiffTool("difft", printValue(*state, *expr->value),
-                              printValue(*state, *expected->value));
+                    runDiffTool("difft", printValue(*state, *expr->value),
+                                printValue(*state, *expected->value));
                 }
 
             } else if (expectedError) {


### PR DESCRIPTION
I found it useful to have a proper diff for failing tests. This patch allows one to run i.e.
`nix-unit --flake ../pyproject.nix/#libTests --diff "difft --color=always"`

to get output like this on test failures:
![image](https://github.com/adisbladis/nix-unit/assets/101753/988f5016-c4b2-40f5-bc73-5e6da622b9e7)

difftastic uses tree-sitter to parse the inputs so it has a relatively correct understanding of nix lang syntactically.

(I am not usually writing C++ and don't really know the language well, hope I didn't make any grave mistakes)