### PR TITLE
Allow testing for evaluation errors

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -2,6 +2,7 @@ src = [
   'nix-unit.cc',
 ]
 
+
 executable('nix-unit', src,
            dependencies : [
              nix_main_dep,

--- a/tests/assets/basic.nix
+++ b/tests/assets/basic.nix
@@ -20,4 +20,26 @@
       expected = "bar";
     };
   };
+
+  testCatchThrow = {
+    expr = throw "I give up";
+    expectedError.type = "ThrownError";
+  };
+
+  testCatchAbort = {
+    expr = abort "Just no";
+    expectedError.type = "Abort";
+  };
+
+  testCatchMessage = {
+    expr = throw "Still about 100 errors to go";
+    expectedError.type = "ThrownError";
+    expectedError.msg = "\\d+ errors";
+  };
+
+  testCatchWrongMessage = {
+    expr = throw "I give up";
+    expectedError.type = "ThrownError";
+    expectedError.msg = "\\d+ errors";
+  };
 }

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -80,6 +80,8 @@ def run_suite(name: str, expected: Dict[str, TestResult], flake: bool):
     get_output_structured(proc.stderr.decode(), results)
 
     for test, expected_result in expected.items():
+        # from pprint import pprint
+        # pprint(results)
         result = results[test]
         if results[test] != expected_result:
             raise ValueError(f"{result} != {expected_result}")
@@ -95,6 +97,13 @@ suites = {
         TestResult("testPass", success=True),
         TestResult("testFail", fail=True),
         TestResult("testFailEval", eval_fail=True),
+        TestResult("testCatchThrow", success=True),
+        TestResult("testCatchAbort", success=True),
+        TestResult("testCatchMessage", success=True),
+        TestResult("testCatchThrow", success=True),
+        TestResult("testCatchAbort", success=True),
+        TestResult("testCatchMessage", success=True),
+        TestResult("testCatchWrongMessage", fail=True),
     ),
 }
 


### PR DESCRIPTION
This (ab)uses the "throw" keyword as magic value in expected which, when set, causes nix-unit to expect an evaluation error to be thrown; just an idea I had after reading the code while implementing #4 

Would fix #2 if merged. 

Possible improvements would allow matching on specific error types as defined nixexpr.hh and/or substrings of the error message.