### PR TITLE
build without -fvisibility=hidden...

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -14,4 +14,4 @@ executable('nix-unit', src,
              threads_dep
            ],
            install: true,
-           cpp_args: ['-std=c++2a', '-fvisibility=hidden'])
+           cpp_args: ['-std=c++2a'])


### PR DESCRIPTION
as it breaks error detection at least on aarch64-darwin. Interestingly it does *not* break other platforms, which seems surprising considering the warning at
https://gcc.gnu.org/wiki/Visibility#Problems_with_C.2B-.2B-_exceptions_.28please_read.21.29a

Anyways, at it does not seem to cause issues on other platforms, so we just remove it